### PR TITLE
BottomNavigationBarを利用した画面遷移

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:text_to_speech_demo/screens/tabs_screen.dart';
 
 import './screens/home_screen.dart';
 import './screens/health_condition.dart';
@@ -38,8 +39,10 @@ class MyApp extends StatelessWidget {
           buttonColor: Colors.amber,
         ),
       ),
-      home: const TitleScreen(),
+      // home: const TitleScreen(),
+      initialRoute: TabsScreen.routeName,
       routes: {
+        TabsScreen.routeName: (context) => const TabsScreen(),
         HomeScreen.routeName: (context) => const HomeScreen(),
         HealthCondition.routeName: (context) => const HealthCondition(),
         PaintScreen.routeName: (context) => const PaintScreen(),

--- a/lib/screens/health_condition.dart
+++ b/lib/screens/health_condition.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../widgets/bottom_tab.dart';
 import '../widgets/generate_grid.dart';
 import '../widgets/generate_caterory.dart';
-import './take_hand.dart';
-import './home_screen.dart';
-import './speech_to_text.dart';
-import './paint_screen.dart';
 
 class HealthCondition extends StatelessWidget {
   static const routeName = '/health-condition';
@@ -191,40 +186,6 @@ class HealthCondition extends StatelessWidget {
                   ),
                 ],
               ),
-            ),
-          ),
-          Container(
-            color: Theme.of(context).colorScheme.primary,
-            height: deviceHeight * 0.13,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                BottomTab(
-                  transitionFunction: () => Navigator.of(context).pop(),
-                  labelText: '戻る',
-                  icon: Icons.undo,
-                ),
-                BottomTab(
-                  transitionFunction: () =>
-                      Navigator.of(context).pushNamed(TakeHand.routeName),
-                  labelText: '取って',
-                  icon: Icons.back_hand,
-                ),
-                BottomTab(
-                  transitionFunction: () => Navigator.of(context).pushNamed(
-                    PaintScreen.routeName,
-                  ),
-                  labelText: '手書き',
-                  icon: Icons.draw,
-                ),
-                BottomTab(
-                  transitionFunction: () => Navigator.of(context)
-                      .pushNamedAndRemoveUntil(
-                          HomeScreen.routeName, (_) => false),
-                  labelText: 'Top',
-                  icon: Icons.home,
-                ),
-              ],
             ),
           ),
         ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -115,151 +115,114 @@ class _HomeScreenState extends State<HomeScreen> {
                 ? const Center(
                     child: CircularProgressIndicator(),
                   )
-                : Column(
-                    children: [
-                      SizedBox(
-                        height: deviceHeight * 0.87,
-                        child: Stack(
-                          children: [
-                            ListView.builder(
-                              itemCount: _journals.length,
-                              itemBuilder: (context, index) {
-                                return Padding(
-                                  padding: const EdgeInsets.only(
-                                    top: 15,
-                                    left: 15,
-                                    right: 15,
-                                    bottom: 7.5,
-                                  ),
-                                  child: GestureDetector(
-                                    onTap: () {
-                                      TextToSpeech.speak(
-                                          _journals[index]["description"]);
-                                    },
-                                    child: Card(
-                                      elevation: 5,
-                                      child: ListTile(
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(20),
-                                        ),
-                                        leading: const Icon(
-                                          Icons.volume_up,
-                                        ),
-                                        title: Text(
-                                          _journals[index]["title"],
-                                          style: const TextStyle(
-                                            fontSize: 24,
-                                            fontWeight: FontWeight.w900,
+                : SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        SizedBox(
+                          height: deviceHeight * 0.87,
+                          child: Stack(
+                            children: [
+                              ListView.builder(
+                                itemCount: _journals.length,
+                                itemBuilder: (context, index) {
+                                  return Padding(
+                                    padding: const EdgeInsets.only(
+                                      top: 15,
+                                      left: 15,
+                                      right: 15,
+                                      bottom: 7.5,
+                                    ),
+                                    child: GestureDetector(
+                                      onTap: () {
+                                        TextToSpeech.speak(
+                                            _journals[index]["description"]);
+                                      },
+                                      child: Card(
+                                        elevation: 5,
+                                        child: ListTile(
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(20),
                                           ),
-                                        ),
-                                        tileColor: Colors.white,
-                                        // Theme.of(context).colorScheme.secondary,
-                                        trailing: SizedBox(
-                                          // width:100になるように iPhone14 Pro MAX width:430/3.4
-                                          width: deviceWidth / 3.9,
-                                          child: Row(
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.end,
-                                            children: [
-                                              IconButton(
-                                                icon: const Icon(Icons.edit),
-                                                onPressed: () => _modal(
-                                                  _journals[index]['id'],
+                                          leading: const Icon(
+                                            Icons.volume_up,
+                                          ),
+                                          title: Text(
+                                            _journals[index]["title"],
+                                            style: const TextStyle(
+                                              fontSize: 24,
+                                              fontWeight: FontWeight.w900,
+                                            ),
+                                          ),
+                                          tileColor: Colors.white,
+                                          // Theme.of(context).colorScheme.secondary,
+                                          trailing: SizedBox(
+                                            // width:100になるように iPhone14 Pro MAX width:430/3.4
+                                            width: deviceWidth / 3.9,
+                                            child: Row(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.end,
+                                              children: [
+                                                IconButton(
+                                                  icon: const Icon(Icons.edit),
+                                                  onPressed: () => _modal(
+                                                    _journals[index]['id'],
+                                                  ),
                                                 ),
-                                              ),
-                                              IconButton(
-                                                icon: const Icon(Icons.delete),
-                                                onPressed: () {
-                                                  showDialog(
-                                                    context: context,
-                                                    builder: (_) {
-                                                      return DeleteDialog(
-                                                        title: _journals[index]
-                                                            ["title"],
-                                                        index: index,
-                                                        journals: _journals,
-                                                        refreshJournals:
-                                                            refreshJournals,
-                                                      );
-                                                    },
-                                                  );
-                                                },
-                                              ),
-                                            ],
+                                                IconButton(
+                                                  icon:
+                                                      const Icon(Icons.delete),
+                                                  onPressed: () {
+                                                    showDialog(
+                                                      context: context,
+                                                      builder: (_) {
+                                                        return DeleteDialog(
+                                                          title:
+                                                              _journals[index]
+                                                                  ["title"],
+                                                          index: index,
+                                                          journals: _journals,
+                                                          refreshJournals:
+                                                              refreshJournals,
+                                                        );
+                                                      },
+                                                    );
+                                                  },
+                                                ),
+                                              ],
+                                            ),
                                           ),
                                         ),
                                       ),
                                     ),
-                                  ),
-                                );
-                              },
-                            ),
-                            GestureDetector(
-                              dragStartBehavior: DragStartBehavior.down,
-                              onPanUpdate: ((details) {
-                                position = details.localPosition;
-                                setState(() {});
-                              }),
-                              child: Stack(
-                                children: [
-                                  Positioned(
-                                    left: position.dx,
-                                    top: position.dy,
-                                    child: FloatingActionButton(
-                                      heroTag: "add",
-                                      child: const Icon(Icons.add),
-                                      onPressed: () => _modal(null),
+                                  );
+                                },
+                              ),
+                              GestureDetector(
+                                dragStartBehavior: DragStartBehavior.down,
+                                onPanUpdate: ((details) {
+                                  position = details.localPosition;
+                                  setState(() {});
+                                }),
+                                child: Stack(
+                                  children: [
+                                    Positioned(
+                                      left: position.dx,
+                                      top: position.dy,
+                                      child: FloatingActionButton(
+                                        heroTag: "add",
+                                        child: const Icon(Icons.add),
+                                        onPressed: () => _modal(null),
+                                      ),
                                     ),
-                                  ),
-                                ],
+                                  ],
+                                ),
                               ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
-                      ),
-                      Container(
-                        height: deviceHeight * 0.13,
-                        color: Theme.of(context).colorScheme.primary,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                          children: [
-                            BottomTab(
-                              transitionFunction: () {
-                                Navigator.of(context)
-                                    .pushNamed(HealthCondition.routeName);
-                              },
-                              labelText: '健康状態',
-                              icon: Icons.medical_services,
-                            ),
-                            BottomTab(
-                              transitionFunction: () {
-                                Navigator.of(context)
-                                    .pushNamed(TakeHand.routeName);
-                              },
-                              labelText: '取って',
-                              icon: Icons.back_hand,
-                            ),
-                            BottomTab(
-                              transitionFunction: () {
-                                Navigator.of(context)
-                                    .pushNamed(InputText.routeName);
-                              },
-                              labelText: '入力',
-                              icon: Icons.keyboard,
-                            ),
-                            BottomTab(
-                              transitionFunction: () =>
-                                  Navigator.of(context).pushNamed(
-                                PaintScreen.routeName,
-                              ),
-                              labelText: '手書き',
-                              icon: Icons.draw,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
           );
         },

--- a/lib/screens/input_text.dart
+++ b/lib/screens/input_text.dart
@@ -90,7 +90,7 @@ class _InputTextState extends State<InputText> {
         child: Column(
           children: [
             SizedBox(
-              height: deviceHeight * 0.2,
+              height: deviceHeight * 0.15,
               child: TextFormField(
                 controller: _inputTextController,
                 enabled: false,
@@ -105,7 +105,7 @@ class _InputTextState extends State<InputText> {
               child: generateButtons(currentType),
             ),
             SizedBox(
-              height: deviceHeight * 0.15,
+              height: deviceHeight * 0.10,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [

--- a/lib/screens/input_text.dart
+++ b/lib/screens/input_text.dart
@@ -36,6 +36,7 @@ class _InputTextState extends State<InputText> {
         AppBar().preferredSize.height -
         MediaQuery.of(context).padding.top -
         MediaQuery.of(context).padding.bottom;
+
     final deviceWidth = MediaQuery.of(context).size.width;
 
     Widget generateButtons(List<List<List<String>>> type) {

--- a/lib/screens/tabs_screen.dart
+++ b/lib/screens/tabs_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:text_to_speech_demo/screens/health_condition.dart';
+import 'package:text_to_speech_demo/screens/home_screen.dart';
+import 'package:text_to_speech_demo/screens/input_text.dart';
+import 'package:text_to_speech_demo/screens/take_hand.dart';
+
+class TabsScreen extends StatefulWidget {
+  static const routeName = "/tabsScreen";
+
+  const TabsScreen({super.key});
+
+  @override
+  State<TabsScreen> createState() => _TabsScreenState();
+}
+
+class _TabsScreenState extends State<TabsScreen> {
+  int _selectedIndex = 0;
+  final List<Widget> _screen = [
+    const HomeScreen(),
+    const HealthCondition(),
+    const TakeHand(),
+    const InputText(),
+  ];
+  void _onTapScreen(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _screen[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        items: [
+          BottomNavigationBarItem(
+            icon: const Icon(
+              Icons.home_outlined,
+            ),
+            activeIcon: const Icon(Icons.home_rounded),
+            label: "Home",
+            backgroundColor: Theme.of(context).colorScheme.primary,
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.medical_services_outlined),
+            activeIcon: const Icon(Icons.medical_services_rounded),
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            label: "健康状態",
+          ),
+          BottomNavigationBarItem(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            icon: const Icon(Icons.back_hand_outlined),
+            activeIcon: const Icon(Icons.back_hand_rounded),
+            label: "取って",
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.keyboard_alt_outlined),
+            activeIcon: const Icon(Icons.keyboard_alt_rounded),
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            label: "入力",
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        onTap: _onTapScreen,
+        elevation: 5,
+        iconSize: 30,
+        selectedItemColor: Colors.white,
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        unselectedItemColor: Colors.white,
+        type: BottomNavigationBarType.fixed,
+      ),
+    );
+  }
+}

--- a/lib/screens/take_hand.dart
+++ b/lib/screens/take_hand.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../widgets/bottom_tab.dart';
-import '../screens/health_condition.dart';
-import '../screens/home_screen.dart';
-import '../screens/paint_screen.dart';
 import '../db/sqlCrud.dart';
 import '../widgets/delete_Dialog.dart';
 import '../widgets/text_to_speech.dart';
@@ -154,41 +150,6 @@ class _TakeHandState extends State<TakeHand> {
                         ),
                       );
                     },
-                  ),
-                ),
-                Container(
-                  height: deviceHeight * 0.13,
-                  color: Theme.of(context).colorScheme.primary,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      BottomTab(
-                        transitionFunction: () => Navigator.of(context).pop(),
-                        labelText: '戻る',
-                        icon: Icons.undo,
-                      ),
-                      BottomTab(
-                        transitionFunction: () => Navigator.of(context)
-                            .pushNamed(HealthCondition.routeName),
-                        labelText: '健康状態',
-                        icon: Icons.medical_services,
-                      ),
-                      BottomTab(
-                        transitionFunction: () =>
-                            Navigator.of(context).pushNamed(
-                          PaintScreen.routeName,
-                        ),
-                        labelText: '手書き',
-                        icon: Icons.draw,
-                      ),
-                      BottomTab(
-                        transitionFunction: () => Navigator.of(context)
-                            .pushNamedAndRemoveUntil(
-                                HomeScreen.routeName, (route) => false),
-                        labelText: 'Top',
-                        icon: Icons.home,
-                      ),
-                    ],
                   ),
                 ),
               ],


### PR DESCRIPTION
## 目的
BottomNavigationBarを利用したナビゲーションメニューを実装した

## なぜこの変更をするのか
それぞれのスクリーンにてナビゲーションを記載する必要がありミスが増加しやすくなるため｡
BottomNavigationを利用することで1つのファイルでメニューを管理することができることから｡

## 実装したこと
* [x] screen/tabs_screen.dart内でナビゲーションメニューを作成する処理を埋め込んだ
<img width="260" alt="スクリーンショット 2023-01-21 12 18 00" src="https://user-images.githubusercontent.com/37583616/213841343-fac3a004-9e5c-418e-b5c1-d4bdc01d3868.png">

## それに伴い生じたエラー
- screen/home_screen.dartにてTextFieldを押した際に発生するキーボード表示がオーバーフローした

## 対処法
- screen/home_screen.dartにて､Columnの上にSingleChildScrollViewをおくことで縦サイズを超えないようにした

## 参考資料

[Positioned()やExpanded()では解決しない理由](https://www.fluttercampus.com/guide/229/incorrect-use-of-parentdatawidget-error/)

[BottomNavigationBar class](https://api.flutter.dev/flutter/material/BottomNavigationBar-class.html)
