### PR TITLE
Edit: iPhone SE3 text size

### DIFF
--- a/lib/widgets/generate_Caterory.dart
+++ b/lib/widgets/generate_Caterory.dart
@@ -15,6 +15,8 @@ class GenerateCaterory extends StatelessWidget {
     final deviceHeight = MediaQuery.of(context).size.height -
         AppBar().preferredSize.height -
         MediaQuery.of(context).padding.top;
+    // Iphone 14 PRO MAX 876.0 24pixcel 固定 0.027
+    // Iphone SE 3 611.0
     return Container(
       width: double.infinity,
       height: deviceHeight * 0.07,
@@ -24,22 +26,29 @@ class GenerateCaterory extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            const Icon(
-              Icons.help,
-              size: 36,
-              color: Colors.white,
-            ),
-            Text(
-              text,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 24,
+            const FittedBox(
+              child: Icon(
+                Icons.help,
+                size: 36,
+                color: Colors.white,
               ),
             ),
-            Icon(
-              icon,
-              size: 36,
-              color: Colors.white,
+            FittedBox(
+              child: Text(
+                text,
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 30,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+            FittedBox(
+              child: Icon(
+                icon,
+                size: 36,
+                color: Colors.white,
+              ),
             )
           ],
         ),


### PR DESCRIPTION
## 目的
iPhone SE系でアプリを動かすと､テキストが一部見えなくすることを防ぐ

## 特に見てほしいところ
- いろんな端末で､テキストが見えなくなることがないか
- 誤字脱字

## 実装したこと
* [x] IconやTextにFittedBoxでラップすることで､親のウィジェットからサイズを受け取りテキストサイズを改善した

| Before | After |
| :---: | :---: |
| <img width = "325" src= "https://user-images.githubusercontent.com/37583616/218295471-83d52a11-7f0a-4119-84e7-a84cf2781f2f.png" alt = "Before Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-12 at 11 33 48"> | <img width = "325" src = "https://user-images.githubusercontent.com/37583616/218295497-38297a46-2720-4854-97ad-132d9e744341.png" alt ="After Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-12 at 11 22 00"> |

